### PR TITLE
IE 11 fix is ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>SGI Interactive Map</title>
     <meta charset="utf-8"/>
+      <meta http-equiv="x-ua-compatible" content="IE=edge">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>SGI Interactive Map</title>
     <meta charset="utf-8"/>
-      <meta http-equiv="x-ua-compatible" content="IE=edge">
+    <meta http-equiv="x-ua-compatible" content="IE=edge">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 

--- a/style.css
+++ b/style.css
@@ -17,6 +17,21 @@ a:focus, a:hover {
     display: block;
 }
 
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .green-slider {
+    display: none;
+  }
+  .blue-slider {
+    display: none;
+  }
+  .purple-slider {
+    display: none;
+  }
+  .red-slider {
+    display: none;
+  }
+}
+
 #header {
 	height: 62px;
 	background-image: url(images/header_bg.jpg);


### PR DESCRIPTION
Hi Brady, 

We have removed the opacity sliders in IE11. It is still working as normal in all other browsers including Microsoft Edge. Please take a look if you have a PC handy. And let me know if see the sliders in IE11. Or if any of your users continue to have trouble. 

Thanks, 

Lou 
